### PR TITLE
feat: refresh site color palette

### DIFF
--- a/assets/images/diagram.svg
+++ b/assets/images/diagram.svg
@@ -1,18 +1,18 @@
-<svg width="500" height="120" xmlns="http://www.w3.org/2000/svg">
+<svg width="500" height="120" xmlns="http://www.w3.org/2000/svg" style="--accent: #29c4f8; --text-dark: #04165d;">
   <defs>
     <marker id="arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#228B22" />
+      <polygon points="0 0, 10 3.5, 0 7" fill="var(--accent)" />
     </marker>
   </defs>
-  <rect x="10" y="40" width="90" height="40" fill="#228B22" />
-  <text x="20" y="65" font-size="12" fill="white">RFID Tags</text>
-  <line x1="100" y1="60" x2="140" y2="60" stroke="#228B22" stroke-width="2" marker-end="url(#arrow)" />
-  <rect x="140" y="40" width="90" height="40" fill="#228B22" />
-  <text x="150" y="65" font-size="12" fill="white">Scanner</text>
-  <line x1="230" y1="60" x2="270" y2="60" stroke="#228B22" stroke-width="2" marker-end="url(#arrow)" />
-  <rect x="270" y="40" width="90" height="40" fill="#228B22" />
-  <text x="280" y="65" font-size="12" fill="white">Kiosk</text>
-  <line x1="360" y1="60" x2="400" y2="60" stroke="#228B22" stroke-width="2" marker-end="url(#arrow)" />
-  <rect x="400" y="40" width="90" height="40" fill="#228B22" />
-  <text x="410" y="65" font-size="12" fill="white">Cloud</text>
+  <rect x="10" y="40" width="90" height="40" fill="var(--accent)" />
+  <text x="20" y="65" font-size="12" fill="var(--text-dark)">RFID Tags</text>
+  <line x1="100" y1="60" x2="140" y2="60" stroke="var(--accent)" stroke-width="2" marker-end="url(#arrow)" />
+  <rect x="140" y="40" width="90" height="40" fill="var(--accent)" />
+  <text x="150" y="65" font-size="12" fill="var(--text-dark)">Scanner</text>
+  <line x1="230" y1="60" x2="270" y2="60" stroke="var(--accent)" stroke-width="2" marker-end="url(#arrow)" />
+  <rect x="270" y="40" width="90" height="40" fill="var(--accent)" />
+  <text x="280" y="65" font-size="12" fill="var(--text-dark)">Kiosk</text>
+  <line x1="360" y1="60" x2="400" y2="60" stroke="var(--accent)" stroke-width="2" marker-end="url(#arrow)" />
+  <rect x="400" y="40" width="90" height="40" fill="var(--accent)" />
+  <text x="410" y="65" font-size="12" fill="var(--text-dark)">Cloud</text>
 </svg>

--- a/styles.css
+++ b/styles.css
@@ -1,10 +1,32 @@
+/*
+  Palette variables:
+  --vivid-sky-blue (#29c4f8)
+  --federal-blue (#04165d)
+  --burnt-umber (#8c271e)
+  --french-gray (#b6b6b9)
+  --ivory (#fbfff1)
+
+  Aliases map palette colors to theme roles:
+  --primary: var(--burnt-umber)
+  --accent: var(--vivid-sky-blue)
+  --accent-light & --white: var(--ivory)
+  --text-dark: var(--federal-blue) (rgb helper --text-dark-rgb)
+  --border: var(--french-gray)
+*/
 :root {
-  --primary: #0950cd;
-  --accent: #3cd2f9;
-  --accent-light: #4af3f8;
-  --text-dark: #04165d;
-  --border: #29c4f8;
-  --white: #ffffff;
+  --vivid-sky-blue: #29c4f8;
+  --federal-blue: #04165d;
+  --burnt-umber: #8c271e;
+  --french-gray: #b6b6b9;
+  --ivory: #fbfff1;
+
+  --primary: var(--burnt-umber);
+  --accent: var(--vivid-sky-blue);
+  --accent-light: var(--ivory);
+  --text-dark: var(--federal-blue);
+  --text-dark-rgb: 4, 22, 93;
+  --border: var(--french-gray);
+  --white: var(--ivory);
   --max-width: 1200px;
 }
 
@@ -91,7 +113,7 @@ nav ul li a:hover {
     right: 0;
     background: var(--white);
     border: 1px solid var(--border);
-    box-shadow: 0 2px 4px rgba(4,22,93,0.1);
+    box-shadow: 0 2px 4px rgba(var(--text-dark-rgb), 0.1);
     padding: 0.5rem 1rem;
     gap: 0.5rem;
     z-index: 1000;
@@ -151,7 +173,7 @@ nav ul li a:hover {
   padding: 2rem;
   text-align: center;
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(4,22,93,0.05);
+  box-shadow: 0 2px 4px rgba(var(--text-dark-rgb), 0.05);
 }
 
 .feature i {
@@ -187,7 +209,7 @@ form {
   background: var(--white);
   padding: 2rem;
   border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(4,22,93,0.05);
+  box-shadow: 0 2px 4px rgba(var(--text-dark-rgb), 0.05);
 }
 
 form .form-group {


### PR DESCRIPTION
## Summary
- update root CSS variables to new vivid blue, federal blue, burnt umber, French gray and ivory scheme
- recolor architecture diagram to match refreshed palette
- replace remaining hard-coded color values with semantic CSS variables
- document palette variables and alias mapping in styles.css

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68961330d6888328a96e4977b7a1ba9e